### PR TITLE
Add secrets/configmap from file and harbor support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV HELM_CONFIG_HOME=/opt/helm
 ENV HELM_REGISTRY_CONFIG=/opt/helm/registry.json
 ENV HELM_REPOSITORY_CONFIG=/opt/helm/repositories.yaml
 ENV HELM_REPOSITORY_CACHE=/opt/helm/cache/repository
-ENV HELM_CACHE_HOME=/opt/helm/cache/helm
+ENV HELM_CACHE_HOME=/opt/helm/cache
 ENV HELM_DATA_HOME=/opt/helm/data
 ENV HELM_PLUGINS=/opt/helm/plugins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 MobileCoin Inc.
-FROM alpine/helm:3.8.0
+FROM alpine/helm:3.8.2
 
 ENV HELM_CONFIG_HOME=/opt/helm
 ENV HELM_REGISTRY_CONFIG=/opt/helm/registry.json
@@ -12,7 +12,8 @@ ENV HELM_PLUGINS=/opt/helm/plugins
 RUN  apk add --no-cache bash curl jq \
   && apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing kubectl \
   && mkdir -p /opt/helm/plugins \
-  && helm plugin install https://github.com/hypnoglow/helm-s3.git
+  && helm plugin install https://github.com/hypnoglow/helm-s3.git \
+  && helm plugin install https://github.com/chartmuseum/helm-push
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,12 @@ inputs:
   chart_repo:
     description: "url for chart repo"
     required: false
+  chart_repo_username:
+    description: "Username for private chart repo"
+    required: false
+  chart_repo_password:
+    description: "Password for private chart repo"
+    required: false
   chart_set:
     description: "new line list of --set commands"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -62,7 +62,7 @@ inputs:
     description: "kubernetes namespace"
     required: false
   object_name:
-    description: "k8s object to scale"
+    description: "k8s object to manipulate"
     required: false
   rancher_project:
     description: "rancher project"

--- a/action.yaml
+++ b/action.yaml
@@ -84,7 +84,7 @@ inputs:
     description: "File to copy into toolbox"
     required: false
 runs:
-  using: 'docker'
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  using: docker
+  image: Dockerfile
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -91,6 +91,6 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -374,6 +374,19 @@ then
                 --from-file="${INPUT_SRC}"
             ;;
 
+        configmap-create-from-file)
+            # Create a secret from file or all files in a directory
+            rancher_get_kubeconfig
+            is_set INPUT_NAMESPACE
+            is_set INPUT_SRC
+            is_set INPUT_OBJECT_NAME
+
+            k delete configmap "${INPUT_OBJECT_NAME}" -n "${INPUT_NAMESPACE}" --now --wait --request-timeout=5m --ignore-not-found
+
+            k create configmap "${INPUT_OBJECT_NAME}" -n "${INPUT_NAMESPACE}" \
+                --from-file="${INPUT_SRC}"
+            ;;
+
         toolbox-copy)
             # Copy files to blue/green fog-ingest toolbox container.
             rancher_get_kubeconfig

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,7 +104,7 @@ then
             rancher_get_kubeconfig
             is_set INPUT_NAMESPACE
             is_set INPUT_INGEST_COLOR
-            
+
             if [ "${INPUT_INGEST_COLOR}" == "blue" ]
             then
                 flipside="green"
@@ -257,7 +257,7 @@ then
                     --sign \
                     --keyring="${INPUT_CHART_PGP_KEYRING_PATH}" \
                     --key="${INPUT_CHART_PGP_KEY}"
-            else 
+            else
                 echo "-- Package unsigned chart"
                 helm package "${INPUT_CHART_PATH}" \
                     -d ".tmp/charts" \
@@ -297,7 +297,7 @@ then
             # Add namespace to Default project
             # Get cluster data and resource links
             echo "-- Query Rancher for cluster info"
-            cluster=$(curl --retry 5 -sSLf -H "${auth_header}" "${INPUT_RANCHER_URL}/v3/clusters/?name=${INPUT_RANCHER_CLUSTER}") 
+            cluster=$(curl --retry 5 -sSLf -H "${auth_header}" "${INPUT_RANCHER_URL}/v3/clusters/?name=${INPUT_RANCHER_CLUSTER}")
 
             namespaces_url=$(echo "${cluster}" | jq -r .data[0].links.namespaces)
             projects_url=$(echo "${cluster}" | jq -r .data[0].links.projects)
@@ -321,7 +321,7 @@ then
             rancher_get_kubeconfig
             is_set INPUT_NAMESPACE
             is_set INPUT_OBJECT_NAME
-            
+
             replicas=$(k get -n "${INPUT_NAMESPACE}" "${INPUT_OBJECT_NAME}" -o=jsonpath='{.spec.replicas}{"\n"}')
             echo "${INPUT_OBJECT_NAME} original scale: ${replicas}"
 
@@ -359,6 +359,19 @@ then
                 --from-literal=FOG_KEYS_SEED="${INPUT_FOG_KEYS_SEED}" \
                 --from-literal=INITIAL_KEYS_SEED="${INPUT_INITIAL_KEYS_SEED}" \
                 --from-literal=FOG_REPORT_SIGNING_CA_CERT="${INPUT_FOG_REPORT_SIGNING_CA_CERT}"
+            ;;
+
+        secrets-create-from-dir)
+            # Create a secret from files in a directory
+            rancher_get_kubeconfig
+            is_set INPUT_NAMESPACE
+            is_set INPUT_SRC
+            is_set INPUT_OBJECT_NAME
+
+            k delete secret "${INPUT_OBJECT_NAME}" -n "${INPUT_NAMESPACE}" --now --wait --request-timeout=5m --ignore-not-found
+
+            k create secret generic "${INPUT_OBJECT_NAME}" -n "${INPUT_NAMESPACE}" \
+                --from-file="${INPUT_SRC}"
             ;;
 
         toolbox-copy)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -361,8 +361,8 @@ then
                 --from-literal=FOG_REPORT_SIGNING_CA_CERT="${INPUT_FOG_REPORT_SIGNING_CA_CERT}"
             ;;
 
-        secrets-create-from-dir)
-            # Create a secret from files in a directory
+        secrets-create-from-file)
+            # Create a secret from file or all files in a directory
             rancher_get_kubeconfig
             is_set INPUT_NAMESPACE
             is_set INPUT_SRC


### PR DESCRIPTION
- add ability to create a configmap or secret from a file or directory (--from-files functionality)
- add helm-publish command that will publish to a chart-museum compatible repo (harbor.mobilecoin.com)
- add ability to specify credentials for a private chart repo.
- remove "random" repo name workaround for static runner environments.