### PR TITLE
Fix helm set typo

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,6 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -199,7 +199,7 @@ then
             then
                 helm_upgrade_with_values repo "${set_options}"
             else
-                helm_upgrade repo "${sets}"
+                helm_upgrade repo "${set_options}"
             fi
             ;;
 


### PR DESCRIPTION
1.0.5 introduced a typo when I changed a variable name to clarify the meaning.  

- change `sets` to `set_options`