### PR TITLE
Reset vaules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,6 +63,7 @@ helm_upgrade()
         if helm upgrade "${INPUT_RELEASE_NAME}" "${repo_name}/${INPUT_CHART_NAME}" \
             -i --wait --timeout="${INPUT_CHART_WAIT_TIMEOUT}" \
             --namespace "${INPUT_NAMESPACE}" \
+            --reset-values \
             --version "${INPUT_CHART_VERSION}" ${sets}
         then
             echo_exit "Deploy Successful"
@@ -86,6 +87,7 @@ helm_upgrade_with_values()
             -i --wait --timeout="${INPUT_CHART_WAIT_TIMEOUT}" \
             -f "${INPUT_CHART_VALUES}" \
             --namespace "${INPUT_NAMESPACE}" \
+            --reset-values \
             --version "${INPUT_CHART_VERSION}" ${sets}
         then
             echo_exit "Deploy Successful"


### PR DESCRIPTION
Looks like helm change the defaults to "reuse-values" if you don't specify a `--set` or values file.  Lets expect that the deployment will always use the fresh values and operators will set what they need every time. 