### PR TITLE
No, really wait for pods ready after scale/restart

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}


### PR DESCRIPTION
The kubectl scale command with --wait doesn't actually wait for the pod to come back up :frowning_face: 

- Add a kubectl wait to match pods by selector labels in the parent config.