### PR TITLE
Adds generic kubectl command

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,33 @@ Copy a file to the blue/green fog-ingest toolbox pod.
 | `src` | `string` | source in action context |
 | `dst` | `string` | destination in toolbox pod |
 
+### kubectl-exec
+
+Run a command on the blue/green fog-ingest toolbox pod.
+
+```yaml
+    - name: Run fog-recovery database migrations
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
+      with:
+        action: kubectl-exec
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        command: |
+          helm template . | k diff -f -
+```
+
+| with | type | description |
+| --- | --- | --- |
+| `ingest_color` | `string` | blue or green |
+| `command` | `string` | command to run on the toolbox pod |
+| `namespace` | `string` | Namespace in target cluster |
+| `rancher_cluster` | `string` | Target cluster name |
+| `rancher_url` | `string` | Rancher Server URL |
+| `rancher_token` | `string` | Rancher API Token |
+| `src` | `string` | source in action context |
+| `dst` | `string` | destination in toolbox pod |
+
 ### toolbox-exec
 
 Run a command on the blue/green fog-ingest toolbox pod.

--- a/README.md
+++ b/README.md
@@ -273,10 +273,10 @@ Copy a file to the blue/green fog-ingest toolbox pod.
 
 ### kubectl-exec
 
-Run a command on the blue/green fog-ingest toolbox pod.
+Run commands that have access to the specified rancher cluster
 
 ```yaml
-    - name: Run fog-recovery database migrations
+    - name: Run kubectl diff to output diff
       uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
       with:
         action: kubectl-exec

--- a/README.md
+++ b/README.md
@@ -289,14 +289,10 @@ Run commands that have access to the specified rancher cluster
 
 | with | type | description |
 | --- | --- | --- |
-| `ingest_color` | `string` | blue or green |
 | `command` | `string` | command to run on the toolbox pod |
-| `namespace` | `string` | Namespace in target cluster |
 | `rancher_cluster` | `string` | Target cluster name |
 | `rancher_url` | `string` | Rancher Server URL |
 | `rancher_token` | `string` | Rancher API Token |
-| `src` | `string` | source in action context |
-| `dst` | `string` | destination in toolbox pod |
 
 ### toolbox-exec
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -528,7 +528,7 @@ then
             echo ""
             k exec -n "${INPUT_NAMESPACE}" "${toolbox}" -c toolbox -- /bin/bash -c "${INPUT_COMMAND}"
             ;;
-        kubectl)
+        kubectl-exec)
 	    # setup kubeconfig and execute supplied command
             rancher_get_kubeconfig
             exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -528,7 +528,11 @@ then
             echo ""
             k exec -n "${INPUT_NAMESPACE}" "${toolbox}" -c toolbox -- /bin/bash -c "${INPUT_COMMAND}"
             ;;
-
+        kubectl)
+	    # setup kubeconfig and execute supplied command
+            rancher_get_kubeconfig
+            exec "$@"
+	    ;;
         *)
             error_exit "Command ${INPUT_ACTION} not recognized"
             ;;


### PR DESCRIPTION
Adds generic `kubectl-exec` action that just
- Sets up the rancher kubeconfig
- Can run any supplied commands that require the kubeconfig

This is in-order to enable running any arbitrary commands against the cluster such as `kubectl diff` and `helm template` from a github action