### PR TITLE
Add logic to progress block chain for full retirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 MobileCoin Inc.
-FROM alpine/helm:3.8.2
+FROM alpine/helm:3.9.3
 
 ENV HELM_CONFIG_HOME=/opt/helm
 ENV HELM_REGISTRY_CONFIG=/opt/helm/registry.json
@@ -12,7 +12,6 @@ ENV HELM_PLUGINS=/opt/helm/plugins
 RUN  apk add --no-cache bash curl jq \
   && apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing kubectl \
   && mkdir -p /opt/helm/plugins \
-  && helm plugin install https://github.com/hypnoglow/helm-s3.git \
   && helm plugin install https://github.com/chartmuseum/helm-push
 
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -186,12 +186,36 @@ Restart pods by scaling the Deployment/StatefulSet to 0 and back to original sca
 | `rancher_url` | `string` | Rancher Server URL |
 | `rancher_token` | `string` | Rancher API Token |
 
-### pvcs-delete
+### pvc-delete
 
-Delete PersistentVolumeClaims in target namespace/cluster.
+Delete a single PersistentVolumeClaims in target namespace/cluster.
 
 ```yaml
-    - name: Delete PersistentVolumeClaims
+    - name: Delete single PVC
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
+      with:
+        action: pvc-delete
+        namespace: my-namespace
+        object_name: my-pvc-0
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+```
+
+| with | type | description |
+| --- | --- | --- |
+| `namespace` | `string` | Namespace in target cluster |
+| `object_name` | `string` | PVC in target namespace |
+| `rancher_cluster` | `string` | Target cluster name |
+| `rancher_url` | `string` | Rancher Server URL |
+| `rancher_token` | `string` | Rancher API Token |
+
+### pvcs-delete
+
+Delete all PersistentVolumeClaims in target namespace/cluster.
+
+```yaml
+    - name: Delete all PersistentVolumeClaims
       uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
       with:
         action: pvcs-delete

--- a/README.md
+++ b/README.md
@@ -90,35 +90,32 @@ Delete a helm release in the target namespace/cluster.
 | `rancher_url` | `string` | Rancher Server URL |
 | `rancher_token` | `string` | Rancher API Token |
 
-### helm-s3-publish
+### helm-publish
 
-Publish a helm chart to an s3 bucket.
-
-⚠️ Note: Run these jobs with a concurrency of one. Running simultaneous uploads to an s3 bucket may cause chart index corruption.
+Publish a helm chart to a harbor repo.
 
 ```yaml
-    - name: Package and publish chart
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
+    - name: Publish chart
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
-        action: helm-s3-publish
-        aws_access_key_id: ${{ secrets.CHARTS_AWS_ACCESS_KEY_ID }}
-        aws_secret_access_key: ${{ secrets.CHARTS_AWS_SECRET_ACCESS_KEY }}
-        aws_default_region: us-east-2
-        chart_repo: s3://charts.mobilecoin.com
-        chart_app_version: 0.0.0-dev
-        chart_version: 0.0.0-dev
-        chart_path: ./chart
+        action: helm-publish
+        chart_repo_username: ${{ secrets.HARBOR_USERNAME }}
+        chart_repo_password: ${{ secrets.HARBOR_PASSWORD }}
+        chart_repo: ${{ env.CHART_REPO }}
+        chart_app_version: ${{ needs.generate-metadata.outputs.tag }}
+        chart_version: ${{ needs.generate-metadata.outputs.tag }}
+        chart_path: .internal-ci/helm/${{ matrix.chart }}
 ```
 
 | with | type | description |
 | --- | --- | --- |
-| `aws_access_key_id` | `string` | AWS Access Key ID for s3 bucket write |
-| `aws_default_region` | `string` | AWS Region for s3 bucket |
-| `aws_secret_access_key` | `string` | AWS Secret Access Key for s3 bucket write |
-| `chart_repo` | `string` | `s3://` Url |
-| `chart_app_version` | `string` | Chart App Version value |
-| `chart_path` | `string` | relative path to chart templates |
-| `chart_version` | `string` | Chart version value |
+| `namespace` | `string` | Namespace in target cluster |
+| `chart_repo_username` | `string` | Harbor user with write access |
+| `chart_repo_password` | `string` | Harbor user with write access |
+| `chart_repo` | `string` | Public Chart Repo Url |
+| `chart_app_version` | `string` | App version |
+| `chart_version` | `string` | Chart version |
+| `chart_path` | `string` | Path to chart files in the repo |
 
 ### namespace-delete
 
@@ -211,35 +208,57 @@ Delete PersistentVolumeClaims in target namespace/cluster.
 | `rancher_url` | `string` | Rancher Server URL |
 | `rancher_token` | `string` | Rancher API Token |
 
-### sample-keys-create-secrets
+### secrets-create-from-file
 
-Create `sample-keys-seeds` secret in target cluster/namespace.
-
-⚠️ Note: Deletes existing secret before creating.
+Create a k8s secret from a file/directory.  Will delete the existing secret and recreate.
 
 ```yaml
-    - name: Create wallet keys seed secrets
-      uses: mobilecoinofficial/gha-k8s-toolbox@v1.0
+    - name: Create wallet key secrets
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
       with:
-        action: sample-keys-create-secrets
-        fog_keys_seed: ${{ steps.seed.outputs.fog_keys_seed }}
-        fog_report_signing_ca_cert: ${{ secrets.FOG_REPORT_SIGNING_CA_CERT }}
-        initial_keys_seed: ${{ steps.seed.outputs.initial_keys_seed }}
-        namespace: my-namespace
+        action: secrets-create-from-file
+        namespace: ${{ inputs.namespace }}
         rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
         rancher_url: ${{ secrets.RANCHER_URL }}
         rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        object_name: some-secret
+        src: .tmp/some-secret
 ```
 
 | with | type | description |
 | --- | --- | --- |
-| `fog_keys_seed` | `string` | seed value for the Fog Keys |
-| `fog_report_signing_ca_cert` | `string` | CA cert for fog report singing, used in Fog Keys generation |
-| `initial_keys_seed` | `string` | seed value for the Initial Keys |
 | `namespace` | `string` | Namespace in target cluster |
 | `rancher_cluster` | `string` | Target cluster name |
 | `rancher_url` | `string` | Rancher Server URL |
 | `rancher_token` | `string` | Rancher API Token |
+| `object_name` | `string` | K8s object to create |
+| `src` | `string` | File/Directory to make into the secret |
+
+### configmap-create-from-file
+
+Create a k8s configmap from a file/directory.  Will delete existing CM and recreate.
+
+```yaml
+    - name: Create wallet key secrets
+      uses: mobilecoinofficial/gha-k8s-toolbox@v1
+      with:
+        action: configmap-create-from-file
+        namespace: ${{ inputs.namespace }}
+        rancher_cluster: ${{ secrets.RANCHER_CLUSTER }}
+        rancher_url: ${{ secrets.RANCHER_URL }}
+        rancher_token: ${{ secrets.RANCHER_TOKEN }}
+        object_name: some-configmap
+        src: .tmp/some-configmap
+```
+
+| with | type | description |
+| --- | --- | --- |
+| `namespace` | `string` | Namespace in target cluster |
+| `rancher_cluster` | `string` | Target cluster name |
+| `rancher_url` | `string` | Rancher Server URL |
+| `rancher_token` | `string` | Rancher API Token |
+| `object_name` | `string` | K8s object to create |
+| `src` | `string` | File/Directory to make into the configmap |
 
 
 ### toolbox-copy

--- a/action.yaml
+++ b/action.yaml
@@ -6,15 +6,6 @@ inputs:
   action:
     description: "builtin action to run (See README.md)"
     required: true
-  aws_access_key_id:
-    description: "aws credential for s3 repo"
-    required: false
-  aws_default_region:
-    description: "aws region for s3 repo"
-    required: false
-  aws_secret_access_key:
-    description: "aws credential for s3 repo"
-    required: false
   chart_app_version:
     description: "chart appVersion for publish"
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -91,7 +91,7 @@ inputs:
     required: false
 runs:
   using: docker
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -82,7 +82,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -193,7 +193,7 @@ then
 
             # does fog_ingest_client have get-ingress-public-key-records
             command="fog_ingest_client --help | grep get-ingress-public-key-records"
-            if toolbox_cmd "${INPUT_NAMESPACE}" "${toolbox}" "${command}"
+            if toolbox_cmd "${toolbox}" "${command}"
             then
                 echo "-- checking for existing key records"
                 command="RUST_LOG=error fog_ingest_client --uri 'insecure-fog-ingest://${instance}-0.${instance}:3226' get-ingress-public-key-records"
@@ -247,7 +247,7 @@ then
                 toolbox_cmd "${toolbox}" "${command}"
 
                 echo "  -- Use Fog test_client to generate blocks to finish retire of ${flipside}"
-                command="/test/fog-test-client.sh --key-dir /tmp/sample_data/fog_keys --token-id 0"
+                command="RUST_LOG=info /test/fog-test-client.sh --key-dir /tmp/sample_data/fog_keys --token-id 0"
 
                 # check active/retired status, if both nodes are not idle we error out.
                 echo "  -- Check ingest status to see if we made it to retired"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -248,6 +248,7 @@ then
 
                 echo "  -- Use Fog test_client to generate blocks to finish retire of ${flipside}"
                 command="RUST_LOG=info /test/fog-test-client.sh --key-dir /tmp/sample_data/fog_keys --token-id 0"
+                toolbox_cmd "${toolbox}" "${command}"
 
                 # check active/retired status, if both nodes are not idle we error out.
                 echo "  -- Check ingest status to see if we made it to retired"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -459,6 +459,16 @@ then
             done
             ;;
 
+        pvc-delete)
+            # Delete a specific PVC
+            rancher_get_kubeconfig
+            is_set INPUT_NAMESPACE
+            is_set INPUT_OBJECT_NAME
+
+            echo "-- Delete PVC ${INPUT_OBJECT_NAME}"
+            k delete pvc "${INPUT_OBJECT_NAME}" -n "${INPUT_NAMESPACE}" --now --wait --request-timeout=5m --ignore-not-found
+            ;;
+
         secrets-create-from-file)
             # Create a secret from file or all files in a directory
             rancher_get_kubeconfig


### PR DESCRIPTION
We need to add logic to progress ingest to full retirement so we can delete the flipside helm deploy. This is so we can do more than 1 upgrade cycle as part of the GHA CI/CD process.

- add logic to progress fog ingest blockchain for full retirement in testing.
- add `pvc-delete` to clean up a specific PVC.
- Add missing docs for `secret-create-from-file` and `configmap-create-from-file`
- remove helm s3 publish 
- bump helm/alpine base container version
- add `toolbox_cmd` function to make toolbox calls a little more DRY