### PR TITLE
Use mobilecoind to finish ingest transition

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+  - small
+  - large

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Generate Docker Tags
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ env.DOCKER_REPO }}
         tags: |
@@ -30,7 +30,7 @@ jobs:
           type=sha,priority=10
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Login to DockerHub
       uses: docker/login-action@v1
@@ -39,7 +39,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and Publish to DockerHub
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: .
         # Don't push on pull_request, just build and check for errors

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -4,7 +4,10 @@ name: tag
 on:
   push:
     branches:
-      - main
+    - main
+  # Refresh images on the first of every month for OS security updates.
+  schedule:
+  - cron: '0 0 1 * *'
 
 jobs:
   tag:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 MobileCoin Inc.
-FROM alpine/helm:3.9.3
+FROM alpine:edge
 
 ENV HELM_CONFIG_HOME=/opt/helm
 ENV HELM_REGISTRY_CONFIG=/opt/helm/registry.json
@@ -9,8 +9,9 @@ ENV HELM_CACHE_HOME=/opt/helm/cache
 ENV HELM_DATA_HOME=/opt/helm/data
 ENV HELM_PLUGINS=/opt/helm/plugins
 
-RUN  apk add --no-cache bash curl jq \
-  && apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing kubectl \
+RUN  apk add --no-cache \
+      --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      bash curl jq kubectl helm git \
   && mkdir -p /opt/helm/plugins \
   && helm plugin install https://github.com/chartmuseum/helm-push
 

--- a/action.yaml
+++ b/action.yaml
@@ -82,7 +82,9 @@ inputs:
     required: false
 runs:
   using: docker
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  # Switch image to Dockerfile and push to a branch for testing changes.
+  # Don't forget to switch back for the PR to release.
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -82,7 +82,7 @@ inputs:
     required: false
 runs:
   using: docker
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1.0
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1.0
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -246,8 +246,8 @@ then
                 command="INITIALIZE_LEDGER='true' FOG_REPORT_URL='fog://fog.${INPUT_NAMESPACE}.development.mobilecoin.com:443' /util/generate_origin_data.sh"
                 toolbox_cmd "${toolbox}" "${command}"
 
-                echo "  -- Use Fog test_client to generate blocks to finish retire of ${flipside}"
-                command="RUST_LOG=info /test/fog-test-client.sh --key-dir /tmp/sample_data/fog_keys --token-id 0"
+                echo "  -- Use mobilecoind to generate blocks to finish retire of ${flipside}"
+                command="/test/mobilecoind-integration-test.sh"
                 toolbox_cmd "${toolbox}" "${command}"
 
                 # check active/retired status, if both nodes are not idle we error out.


### PR DESCRIPTION
Move to using mobilecoind to progress blockchain for new fog-ingest activation.  This way we don't have to rely on other fog services during the transition.

- Chore: update base image version and move to official alpine image.
- Move to mobilecoind test to move blockchain forward.
- Add actionlint profile and GHA cron to bump patch tag so we update OS images at least one a month.