### PR TITLE
exit gracefully if the namespace already exists

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -392,7 +392,13 @@ then
 
             echo "-- Create namespace ${INPUT_NAMESPACE}"
             # Don't sweat it if the namespace already exists.
-            k create ns "${INPUT_NAMESPACE}" || echo "Namespace already exists"
+            if k create ns "${INPUT_NAMESPACE}"
+            then
+                echo "Namespace created"
+            else
+                echo "Namespace already exists"
+                exit 0
+            fi
 
             auth_header="Authorization: Bearer ${INPUT_RANCHER_TOKEN}"
 


### PR DESCRIPTION
Quick fix exit gracefully if the namespace already exists.  Allows us to create the namespace by hand if needed.