### PR TITLE
fix: Include branch in generate-metadata version

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
   using: docker
   # Switch image to Dockerfile and push to a branch for testing changes.
   # Don't forget to switch back for the PR to release.
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
   using: docker
   # Switch image to Dockerfile and push to a branch for testing changes.
   # Don't forget to switch back for the PR to release.
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1
   args:
   - ${{ inputs.command }}

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -100,6 +100,9 @@ EOF
     # Branches and pull requests will set type as branch.
     # Don't filter on "valid" branches, rely on workflows to filter out their accepted events.
     branch)
+        # All branch builds will just have a "dummy" tag.
+        version="v0"
+
         echo "Clean up branch. Remove feature|release prefix and replace ._/ with -"
         normalized_branch="$(normalize_ref_name "${branch}")"
 
@@ -124,8 +127,7 @@ EOF
         echo "After: '${normalized_branch}'"
 
         # Set version and artifact tags
-	version="v0-${normalized_branch}"
-        tag="${version}.${GITHUB_RUN_NUMBER}.${sha}"
+        tag="${version}-${normalized_branch}.${GITHUB_RUN_NUMBER}.${sha}"
         # Set docker metadata action compatible tag
         docker_tag="type=raw,value=${tag}"
         # Set namespace from normalized branch value
@@ -138,8 +140,9 @@ EOF
 esac
 
 # Set GHA output vars
+# Make version output as tag.  Maybe remove from output later to reduce confusion.
 cat <<EOO >> "${GITHUB_OUTPUT}"
-version=${version}
+version=${tag}
 namespace=${namespace}
 sha=${sha}
 tag=${tag}

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -9,12 +9,12 @@ export TMPDIR=".tmp"
 
 is_set()
 {
-  var_name="${1}"
+    var_name="${1}"
 
-  if [[ -z "${!var_name}" ]]; then
-    echo "${var_name} is not set." >&2
-    exit 1
-  fi
+    if [[ -z "${!var_name}" ]]; then
+        echo "${var_name} is not set." >&2
+        exit 1
+    fi
 }
 
 normalize_ref_name()


### PR DESCRIPTION
The `version` output is currently the same across branches, so include the normalized branch/ref name in the `version`.
Also convert to lowercase as part of normalization, since Dependabot creates PRs with camelCase names in Kotlin repos.
Also includes a small fix for inconsistent indentation.

This is effectively a port of https://github.com/mobilecoinofficial/twix/pull/574 and https://github.com/mobilecoinofficial/twix/pull/561