### PR TITLE
trim - from the end of branches

### DIFF
--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -120,7 +120,8 @@ EOF
         then
             cut_branch=$(echo "${normalized_branch}" | cut -c -${cutoff})
             echo "Your branch name ${normalized_branch} + metadata exceeds the maximum length for K8s identifiers, truncating to ${cut_branch}"
-            normalized_branch="${cut_branch}"
+            # cut branch should not end in - trim any dashes from the end.
+            normalized_branch="${cut_branch%%*(-)}"
         fi
 
         echo "Before: '${branch}'"
@@ -138,6 +139,8 @@ EOF
         exit 1
     ;;
 esac
+
+# namespace cannot end in a - or .
 
 # Set GHA output vars
 # Make version output as tag.  Maybe remove from output later to reduce confusion.

--- a/util/metadata.sh
+++ b/util/metadata.sh
@@ -140,8 +140,6 @@ EOF
     ;;
 esac
 
-# namespace cannot end in a - or .
-
 # Set GHA output vars
 # Make version output as tag.  Maybe remove from output later to reduce confusion.
 cat <<EOO >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Namespace is derived from the branch name. Normally branches can't end in a non word character.  The problem is when we trim a branch name to fit in the 64 character namespace name limit.

Trim the `-` from the end of a truncated branch name. 