### PR TITLE
Add oci helm push

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
   using: docker
   # Switch image to Dockerfile and push to a branch for testing changes.
   # Don't forget to switch back for the PR to release.
-  # image: Dockerfile
-  image: docker://mobilecoin/gha-k8s-toolbox:v1
+  image: Dockerfile
+  # image: docker://mobilecoin/gha-k8s-toolbox:v1
   args:
   - ${{ inputs.command }}

--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
   using: docker
   # Switch image to Dockerfile and push to a branch for testing changes.
   # Don't forget to switch back for the PR to release.
-  image: Dockerfile
-  # image: docker://mobilecoin/gha-k8s-toolbox:v1
+  # image: Dockerfile
+  image: docker://mobilecoin/gha-k8s-toolbox:v1
   args:
   - ${{ inputs.command }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -416,7 +416,7 @@ then
 
             echo "-- Push OCI chart"
             chart_name=$(basename "${INPUT_CHART_PATH}")
-            helm push --force ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" oci://"${INPUT_CHART_REPO}"
+            helm push ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" oci://"${INPUT_CHART_REPO}"
             ;;
 
         namespace-delete)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -412,11 +412,11 @@ then
             helm_package
 
             echo "-- Login OCI registry ${INPUT_CHART_REPO}, as ${INPUT_CHART_REPO_USERNAME}"
-            echo "${INPUT_CHART_REPO_PASSWORD}" | helm registry login ${INPUT_CHART_REPO} --username ${INPUT_CHART_REPO_USERNAME} --password-stdin
+            echo "${INPUT_CHART_REPO_PASSWORD}" | helm registry login "${INPUT_CHART_REPO}" --username "${INPUT_CHART_REPO_USERNAME}" --password-stdin
 
             echo "-- Push OCI chart"
             chart_name=$(basename "${INPUT_CHART_PATH}")
-            helm push ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" oci://"${INPUT_CHART_REPO}"
+            helm push ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" "oci://${INPUT_CHART_REPO}"
             ;;
 
         namespace-delete)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -409,11 +409,6 @@ then
             is_set INPUT_CHART_REPO_PASSWORD
             is_set INPUT_CHART_REPO_USERNAME
 
-            if [[ "${INPUT_CHART_REPO}" != oci* ]]
-            then
-                error_exit "INPUT_CHART_REPO must be an OCI Repository"
-            fi
-
             helm_package
 
             echo "-- Login OCI registry ${INPUT_CHART_REPO}, as ${INPUT_CHART_REPO_USERNAME}"
@@ -421,7 +416,7 @@ then
 
             echo "-- Push OCI chart"
             chart_name=$(basename "${INPUT_CHART_PATH}")
-            helm push --force ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" "${INPUT_CHART_REPO}"
+            helm push --force ".tmp/charts/${chart_name}-${INPUT_CHART_VERSION}.tgz" oci://"${INPUT_CHART_REPO}"
             ;;
 
         namespace-delete)


### PR DESCRIPTION
Adding `helm-publish-oci`.   By passing in `${{ github.actor }}` and `${{ github.token }}` for `chart_repo_username` and `chart_repo_password` (respectively), and `ghcr.io/<orgname>` as the `chart_repo`, we can push to an OCI registry.  And in this case, the Github Container Registry.